### PR TITLE
Add gitignore for pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.pytest_cache/


### PR DESCRIPTION
## Summary
- add a repo-wide `.gitignore` so pytest cache isn't committed

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_686fc10b96bc832ca08ca42222402c35