### PR TITLE
Fix invalid Error usage in TextNode handler

### DIFF
--- a/src/textnode.py
+++ b/src/textnode.py
@@ -41,4 +41,4 @@ def text_node_to_html_node(text_node):
         case TextType.IMAGE:
             return LeafNode(tag="img", value="", props={"src": text_node.url, "alt": text_node.text})
         case _:
-            raise Error("falty object")
+            raise ValueError("faulty TextNode")


### PR DESCRIPTION
## Summary
- fix exception type in `text_node_to_html_node`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc0fafe44832cbb648975c6141dc0